### PR TITLE
Backported parallel classloading for plugin classloader.

### DIFF
--- a/de.tototec.sbuild.runner/src/main/scala/de/tototec/sbuild/runner/ProjectClassLoader.scala
+++ b/de.tototec.sbuild.runner/src/main/scala/de/tototec/sbuild/runner/ProjectClassLoader.scala
@@ -22,16 +22,8 @@ class ProjectClassLoader(project: Project, classpathUrls: Seq[URL], parent: Clas
     ClassLoader.registerAsParallelCapable()
   }
 
-  private[this] val classLockMap = new ConcurrentHashMap[String, Any]
-
   protected def getClassLock(className: String): AnyRef =
-    ParallelClassLoader.withJava7 { () => getClassLoadingLock(className) }.getOrElse {
-      val newLock = new Object()
-      classLockMap.putIfAbsent(className, newLock) match {
-        case null => newLock
-        case lock => lock.asInstanceOf[AnyRef]
-      }
-    }
+    ParallelClassLoader.withJava7 { () => getClassLoadingLock(className) }.getOrElse { this }
 
   val pluginClassLoaders: Seq[PluginClassLoader] = classpathTrees.collect {
     case cpTree if cpTree.pluginInfo.isDefined => new PluginClassLoader(project, cpTree.pluginInfo.get, cpTree.childs, this)


### PR DESCRIPTION
After a review of the Java ClassLoader documentation, it turned out, the only way to got with a non-strict-hierarchical classloader is to be parallel classloading capable.
