### PR TITLE
Changed classpath.properties parsing. (#197)

### DIFF
--- a/org.sbuild.runner/src/test/scala/org/sbuild/runner/ClasspathConfigTest.scala
+++ b/org.sbuild.runner/src/test/scala/org/sbuild/runner/ClasspathConfigTest.scala
@@ -11,15 +11,15 @@ class ClasspathConfigTest extends FunSuite {
 
     val props = new Properties()
     props.setProperty("sbuildClasspath", "de.tototec.sbuild-0.1.3.jar");
-    props.setProperty("compileClasspath", "/tmp/scala-library-2.9.2.jar;/tmp/scala-compiler-2.9.2.jar");
-    props.setProperty("projectRuntimeClasspath", "de.tototec.sbuild.ant-0.1.3.jar:/tmp/de.tototec.sbuild.addons-svn.jar")
+    props.setProperty("compileClasspath", "scala-library-2.9.2.jar;scala-compiler-2.9.2.jar");
+    props.setProperty("projectRuntimeClasspath", "de.tototec.sbuild.ant-0.1.3.jar:de.tototec.sbuild.addons-svn.jar")
 
     val config = new ClasspathConfig()
     config.readFromProperties(new File("/home/sbuild/bin/sbuild-dir/lib"), props);
 
-    assert(Array("/home/sbuild/bin/sbuild-dir/lib/de.tototec.sbuild-0.1.3.jar") === config.sbuildClasspath)
-    assert(Array("/tmp/scala-library-2.9.2.jar", "/tmp/scala-compiler-2.9.2.jar") === config.compileClasspath)
-    assert(Array("/home/sbuild/bin/sbuild-dir/lib/de.tototec.sbuild.ant-0.1.3.jar", "/tmp/de.tototec.sbuild.addons-svn.jar") === config.projectRuntimeClasspath)
+    assert(Array(new File("/home/sbuild/bin/sbuild-dir/lib/de.tototec.sbuild-0.1.3.jar")) === config.sbuildClasspath)
+    assert(Array(new File("/home/sbuild/bin/sbuild-dir/lib/scala-library-2.9.2.jar"), new File("/home/sbuild/bin/sbuild-dir/lib/scala-compiler-2.9.2.jar")) === config.compileClasspath)
+    assert(Array(new File("/home/sbuild/bin/sbuild-dir/lib/de.tototec.sbuild.ant-0.1.3.jar"), new File("/home/sbuild/bin/sbuild-dir/lib/de.tototec.sbuild.addons-svn.jar")) === config.projectRuntimeClasspath)
   }
 
 }


### PR DESCRIPTION
Now, all entries are handled as files relative to the properties file. The
internal API also uses File instead of String.

This PR fi x#197
