### PR TITLE
Fixed missing %-sign on variable check.

### DIFF
--- a/sbuild-dist/SBuild.scala
+++ b/sbuild-dist/SBuild.scala
@@ -153,7 +153,7 @@ class SBuild(implicit _project: Project) {
          |if "%OS%"=="WINNT" @setlocal
          |
          |@REM Find SBuild home dir
-         |if NOT "%SBUILD_HOME"=="" goto valSHome
+         |if NOT "%SBUILD_HOME%"=="" goto valSHome
          |
          |if "%OS%"=="Windows_NT" SET "SBUILD_HOME=%~dp0.."
          |if "%OS%"=="WINNT" SET "SBUILD_HOME=%~dp0.."


### PR DESCRIPTION
This should also remove the need for an environment variable SBUILD_HOME on windows systems (tested with win8 only).

If that environment variable is no longer needed, the installation of sbuild becomes easier and the flexibility of using multiple sbuild installations is improved.
